### PR TITLE
RSE Changes v4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,3 +101,15 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     # Stricter warnings
     target_compile_options(hybird PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/W4>")
 endif()
+
+# Static stdlib (required by Intel VTune)
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    option(HYBIRD_STATIC_STDLIB "If enabled link against static stdlib, only necessary for Intel VTune profiler." OFF)
+    # Required for intel vtune
+    if (HYBIRD_STATIC_STDLIB)
+        target_link_options(hybird PRIVATE -static-libgcc -static-libstdc++)
+    endif()
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    # todo, test the correct configuration for MSVC 
+    # set_property(TARGET hybird PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()

--- a/src/IO.h
+++ b/src/IO.h
@@ -63,7 +63,7 @@ public:
     // Formats for output
     enum ParaviewFormat {
         Binary, BinaryLowMem, Ascii
-    } fluidLagrangianFormat = ParaviewFormat::Binary;
+    } fluidLagrangianFormat = Binary, partExpFormat = Binary;
     // recycle intervals
     double fluidRecycleExpTime, partRecycleExpTime, outputExpTime;
     // file for storing indices of single objects to export
@@ -118,6 +118,7 @@ private:
     unsigned int lastPartExp;
     string partFileFormat;
     void exportParaviewParticles(const elmtList& elmts, const particleList& particles, const string& particleFile);
+    void exportParaviewParticles_binaryv3(const elmtList& elmts, const particleList& particles, const string& particleFile);
     
     // object paraview file
     unsigned int lastObjectExp;

--- a/src/IO.h
+++ b/src/IO.h
@@ -60,6 +60,10 @@ public:
     double maxTime;
     // intervals for output
     double screenExpTime, stateExpTime, fluidExpTime, fluidLagrangianExpTime, fluid2DExpTime, partExpTime, objectExpTime, singleObjectExpTime, cylinderExpTime;
+    // Formats for output
+    enum ParaviewFormat {
+        Binary, BinaryLowMem, Ascii
+    } fluidLagrangianFormat = ParaviewFormat::Binary;
     // recycle intervals
     double fluidRecycleExpTime, partRecycleExpTime, outputExpTime;
     // file for storing indices of single objects to export
@@ -129,6 +133,9 @@ private:
     unsigned int lastFluidExp;
     string fluidFileFormat;
     void exportEulerianParaviewFluid(const LB& lb, const string& fluidFile);
+    void exportEulerianParaviewFluid_binary(const LB& lb, const string& fluidFile);
+    void exportEulerianParaviewFluid_binaryv2(const LB& lb, const string& fluidFile);
+    void exportEulerianParaviewFluid_binaryv3(const LB& lb, const string& fluidFile);
     
     // Lagrangian fluid paraview file
     unsigned int lastFluidLagrangianExp;

--- a/src/LB.cpp
+++ b/src/LB.cpp
@@ -624,7 +624,7 @@ void LB::latticeBolzmannStep(elmtList& elmts, particleList& particles, wallList&
     }
     #pragma omp barrier
 
-    #pragma omp for //schedule(guided, 100)
+    #pragma omp for schedule(guided, 100)
     for (int it = 0; it < activeNodes.size(); ++it) {
         node* nodeHere = activeNodes[it];
 

--- a/src/LB.h
+++ b/src/LB.h
@@ -169,6 +169,10 @@ public:
     // age coefficients for new nodes
     const double maxAge=200.0;
     const double ageRatio=1.0/maxAge;
+    // extra mass due to bounce-back and moving walls
+    // This is a reduction variable used by LB::streaming()
+    // It is defined at a class level so it can be shared by OpenMP threads
+    double extraMass = 0.0;
     // standard constructor
 public:
 

--- a/src/LB.h
+++ b/src/LB.h
@@ -216,14 +216,13 @@ public:
     void initializeVariables();
     void initializeWalls(wallList& walls, cylinderList& cylinders, objectList& objects);
     // integration functions
-    void reconstruction();
-    void collision();
+    void collision(node* nodeHere);
     void streaming(wallList& walls, objectList& objects);
     double curvedWallReconstruction(const unsigned int& j, const node* nodeHere, const tVect& wallSpeed) const;
     // error dumping functions
     void cleanLists();
     // coupling functions
-    void computeHydroForces(elmtList& elmts, particleList& particles);
+    void computeHydroForces(node* nodeHere, elmtList& elmts, particleList& particles);
     void findNewActive(nodeList& newPopUpNodes, elmtList& elmts, particleList& particles);
     void findNewSolid(nodeList& newSolidNodes, elmtList& elmts, particleList& particles);
     void activeToSolid(unsIntList& newSolidNodes, elmtList& elmts, double& massSurplus);

--- a/src/hybird.cpp
+++ b/src/hybird.cpp
@@ -136,8 +136,12 @@ void parseCommandLine(IO& io, GetPot& commandLine) {
         int a;
         a = filesystem::create_directories(io.workDirectory);
         cout << "Work directory created = " << io.workDirectory << ". Result: " << a << "\n";
-
-        std::system(("cp '" + io.configFileName + "' '" + io.workDirectory + "'").c_str());
+        try  {
+            std::filesystem::copy_file(io.configFileName,
+                std::filesystem::path(io.workDirectory)/std::filesystem::path(io.configFileName).filename());
+        } catch (std::filesystem::filesystem_error& e) {
+            cout << "Failed to copy config to working directory. Result: " << e.what() << "\n";
+        }
     }
     // make sure the config files can be read
     std::ifstream configFile(io.configFileName.c_str());

--- a/src/hybird.cpp
+++ b/src/hybird.cpp
@@ -221,6 +221,23 @@ void parseConfigFile(IO& io, DEM& dem, LB& lb, GetPot& configFile, GetPot& comma
     ASSERT(io.fluidExpTime >= 0);
     PARSE_CLASS_MEMBER(configFile, io.fluidLagrangianExpTime, "fluidLagrangianExpTime", 0.0);
     ASSERT(io.fluidLagrangianExpTime >= 0);
+    if (io.fluidLagrangianExpTime > 0.0) {
+        string fluidLagrangianFormatString;
+        PARSE_CLASS_MEMBER(configFile, fluidLagrangianFormatString, "fluidLagrangianFormat", "BINARY");
+        std::transform(fluidLagrangianFormatString.begin(), fluidLagrangianFormatString.end(), fluidLagrangianFormatString.begin(), ::tolower);
+        if (fluidLagrangianFormatString == "ascii"
+         || fluidLagrangianFormatString == "text"
+         || fluidLagrangianFormatString == "txt") {
+            io.fluidLagrangianFormat = IO::ParaviewFormat::Ascii;
+         } else if (fluidLagrangianFormatString == "binary_low_memory"
+                 || fluidLagrangianFormatString == "binary_lowmem"
+                 || fluidLagrangianFormatString == "low_memory"
+                 || fluidLagrangianFormatString == "lowmem") {
+             io.fluidLagrangianFormat = IO::ParaviewFormat::BinaryLowMem;
+         } else { // "binary"
+                     io.fluidLagrangianFormat = IO::ParaviewFormat::Binary;
+         }
+    }
     PARSE_CLASS_MEMBER(configFile, io.fluid2DExpTime, "fluid2DExpTime", 0.0);
     ASSERT(io.fluid2DExpTime >= 0);
     PARSE_CLASS_MEMBER(configFile, io.partExpTime, "partExpTime", 0.0);

--- a/src/hybird.cpp
+++ b/src/hybird.cpp
@@ -409,6 +409,7 @@ int main(int argc, char** argv) {
     const auto chrono_start = std::chrono::steady_clock::now();
     // Checking number of processes involved
 #ifdef USE_OPENMP
+    //omp_set_num_threads(8);
     #pragma omp parallel
     {
         #pragma omp single
@@ -494,7 +495,6 @@ int main(int argc, char** argv) {
     // CYCLE /////////////////////////////
     // integrate in time
     while (true) {
-
         if (io.realTime != 0.0 && io.realTime > io.maxTime) {
             exit_code = SUCCESS;
         }// exit normally if the maximum simulation time has been reached

--- a/src/hybird.cpp
+++ b/src/hybird.cpp
@@ -242,6 +242,18 @@ void parseConfigFile(IO& io, DEM& dem, LB& lb, GetPot& configFile, GetPot& comma
     ASSERT(io.fluid2DExpTime >= 0);
     PARSE_CLASS_MEMBER(configFile, io.partExpTime, "partExpTime", 0.0);
     ASSERT(io.partExpTime >= 0);
+    if (io.partExpTime > 0.0) {
+        string partExpFormatString;
+        PARSE_CLASS_MEMBER(configFile, partExpFormatString, "partExpFormat", "BINARY");
+        std::transform(partExpFormatString.begin(), partExpFormatString.end(), partExpFormatString.begin(), ::tolower);
+        if (partExpFormatString == "ascii"
+         || partExpFormatString == "text"
+         || partExpFormatString == "txt") {
+            io.partExpFormat = IO::ParaviewFormat::Ascii;
+        } else { // "binary"
+            io.partExpFormat = IO::ParaviewFormat::Binary;
+        }
+    }
     PARSE_CLASS_MEMBER(configFile, io.fluidRecycleExpTime, "fluidRecycleExpTime", 0.0);
     ASSERT(io.fluidRecycleExpTime >= 0);
     PARSE_CLASS_MEMBER(configFile, io.partRecycleExpTime, "partRecycleExpTime", 0.0);

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -558,54 +558,6 @@ bool node::isCurvedWall() const {
     }
 }
 
-bool node::isSlipStatWall() const {
-    return type == SLIP_STAT_WALL;
-}
-
-bool node::isSlipDynWall() const {
-    return type == SLIP_DYN_WALL;
-}
-
-bool node::isStatWall() const {
-    return type == STAT_WALL;
-}
-
-bool node::isDynWall() const {
-    return type == DYN_WALL;
-}
-
-bool node::isCylinderWall() const {
-    return type == CYL;
-}
-
-bool node::isObjectWall() const {
-    return type == OBJ;
-}
-
-bool node::isTopography() const {
-    return type == TOPO;
-}
-
-bool node::isOutlet() const {
-    return type == OUTLET;
-}
-
-bool node::isInterface() const {
-    return type == INTERFACE;
-}
-
-bool node::isFluid() const {
-    return type == LIQUID;
-}
-
-bool node::isGas() const {
-    return type == GAS;
-}
-
-bool node::isPeriodic() const {
-    return type == PERIODIC;
-}
-
 // functions for change of type
 
 void node::setSlipStatWall() {
@@ -662,10 +614,6 @@ void node::setType(const types& typ) {
 }
 
 // particle flag
-
-bool node::isInsideParticle() const {
-    return p;
-}
 
 void node::setInsideParticle() {
     p = true;

--- a/src/node.h
+++ b/src/node.h
@@ -175,18 +175,18 @@ public:
     bool isActive() const;
     bool isWall() const;
     bool isCurvedWall() const;
-    bool isSlipStatWall() const; 
-    bool isSlipDynWall() const;
-    bool isStatWall() const;
-    bool isDynWall() const;
-    bool isCylinderWall() const;
-    bool isObjectWall() const;
-    bool isTopography() const;
-    bool isOutlet() const;
-    bool isInterface() const;
-    bool isFluid() const;
-    bool isGas() const;
-    bool isPeriodic() const;
+    inline bool isSlipStatWall() const { return type == SLIP_STAT_WALL; }
+    inline bool isSlipDynWall() const { return type == SLIP_DYN_WALL; }
+    inline bool isStatWall() const { return type == STAT_WALL; }
+    inline bool isDynWall() const { return type == DYN_WALL; }
+    inline bool isCylinderWall() const { return type == CYL; }
+    inline bool isObjectWall() const { return type == OBJ; }
+    inline bool isTopography() const { return type == TOPO; }
+    inline bool isOutlet() const { return type == OUTLET; }
+    inline bool isInterface() const { return type == INTERFACE; }
+    inline bool isFluid() const { return type == LIQUID; }
+    inline bool isGas() const { return type == GAS; }
+    inline bool isPeriodic() const { return type == PERIODIC; }
     // functions for change of type
     void setSlipStatWall();
     void setSlipDynWall();
@@ -203,7 +203,7 @@ public:
     void setType(const types& typ);
     //unsigned int getType() const;
     // particle flag
-    bool isInsideParticle() const;
+    inline bool isInsideParticle() const { return p; };
     void setInsideParticle();
     void setOutsideParticle();
     // functions to get and assign index

--- a/tutorials/bingham_flow/bingham_flow.cfg
+++ b/tutorials/bingham_flow/bingham_flow.cfg
@@ -14,6 +14,7 @@ problemName             = NULL	    #
 screenExpTime           = 0.1		    # print data on screen every x time (0 for deactivated)
 fluidExpTime            = 0		    # write vtk file every x time (0 for deactivated)
 fluidLagrangianExpTime  = 1.0		    # write Lagrangian vtk file every x time (0 for deactivated)
+fluidLagrangianFormat   = ASCII     # ASCII/BINARY/BINARY_LOWMEM (defaults BINARY, fastest/smallest, requires extra RAM)
 partExpTime             = 0			    # write vtk file every x time (0 for deactivated)
 partRecycleExpTime      = 0		    # write particle recycle file every x time (0 for deactivated)
 fluidRecycleExpTime     = 0		    # write particle recycle file every x simulation time units (0 for deactivated)

--- a/tutorials/granular_column/granular_colum.cfg
+++ b/tutorials/granular_column/granular_colum.cfg
@@ -15,6 +15,7 @@ screenExpTime           = 1.0e-2		    # print data on screen every x time (0 for
 fluidExpTime            = 0		    # write vtk file every x time (0 for deactivated)
 fluidLagrangianExpTime  = 0		    # write Lagrangian vtk file every x time (0 for deactivated)
 partExpTime             = 1.0e-2			    # write vtk file every x time (0 for deactivated)
+partExpFormat           = ASCII		# ASCII/BINARY (defaults BINARY, fastest/smallest)
 partRecycleExpTime      = 1.0e-1		    # write particle recycle file every x time (0 for deactivated)
 fluidRecycleExpTime     = 0		    # write particle recycle file every x simulation time units (0 for deactivated)
 fluid2DExpTime          = 0         # write a 2D topographycal file every x time. Maximum values are updated every screenExpTime

--- a/tutorials/granular_flow/granular_flow.cfg
+++ b/tutorials/granular_flow/granular_flow.cfg
@@ -14,6 +14,7 @@ problemName             = NULL	    #
 screenExpTime           = 0.1		    # print data on screen every x time (0 for deactivated)
 fluidExpTime            = 0		    # write vtk file every x time (0 for deactivated)
 fluidLagrangianExpTime  = 1.0		    # write Lagrangian vtk file every x time (0 for deactivated)
+fluidLagrangianFormat   = ASCII     # ASCII/BINARY/BINARY_LOWMEM (defaults BINARY, fastest/smallest, requires extra RAM)
 partExpTime             = 0			    # write vtk file every x time (0 for deactivated)
 partRecycleExpTime      = 0		    # write particle recycle file every x time (0 for deactivated)
 fluidRecycleExpTime     = 0		    # write particle recycle file every x simulation time units (0 for deactivated)

--- a/tutorials/tsunami_wave/tsunami_wave.cfg
+++ b/tutorials/tsunami_wave/tsunami_wave.cfg
@@ -15,6 +15,7 @@ screenExpTime           = 1.0e-2		    # print data on screen every x time (0 for
 fluidExpTime            = 1.0e-2		    # write vtk file every x time (0 for deactivated)
 fluidLagrangianExpTime  = 0		    # write Lagrangian vtk file every x time (0 for deactivated)
 partExpTime             = 1.0e-2			    # write vtk file every x time (0 for deactivated)
+partExpFormat           = ASCII		# ASCII/BINARY (defaults BINARY, fastest/smallest)
 partRecycleExpTime      = 1.0e-1		    # write particle recycle file every x time (0 for deactivated)
 fluidRecycleExpTime     = 0		    # write particle recycle file every x simulation time units (0 for deactivated)
 fluid2DExpTime          = 0         # write a 2D topographycal file every x time. Maximum values are updated every screenExpTime


### PR DESCRIPTION
Restructured `LB::latticeBolzmannStep` so most sits within a single `#pragma omp parallel` section, and tweaked `reconstruct`, `computeHydroForces`, `collision` so that they can share a single `#pragma omp for`.

Runtime of granular collapse test case now down to 6722s, from ~9500s.
This slightly reduces the number of synchronisation points and the overhead of creating/destroying parallel sections.

**Due to this involving some restructuring, and the potential for misuse of OpenMP, the outputs require validation before this is merged.**

Sample output can be found [here](https://drive.google.com/file/d/1AR-6GX8rqTJBToMQ2aQvsc2nhuNIb6zE/view?usp=drive_link) (Warning, ~220mb download, 1.6gb after extraction)


## ChangeLog

* `LB::latticeBolzmannStep()` updated so it uses a single OpenMP parallel block, rather than many separate
    * Runtime of granular collapse test case now down to 6722s, from ~9500s.
* Enabled OpenMP (guided, 100) schedule for main OpenMP loop, this gives a minor 2% improvement over the default (static, 1)
* Replaced `std::system("cp ...` with `std::filesystem::copyfile()`
    * Using `std::system()` is grim and not cross-platform
    - [ ] Todo, what is the desired behaviour of the `.cfg` file already exists in the working directory? Overwrite or fail silently.
* Added cmake option `HYBIRD_STATIC_STDLIB`
    * This causes `hybird` to be built with static rather than dynamic `stdlib`.
    * This is required for profiling with Intel VTune which I've been using, so you can probably ignore this option.
* `exportEulerianParaviewFluid_binary()` + `..v2()` + `..v3()`
   * 3 versions that export eulerian paraview fluid files in binary
   * 10-30x speedup, v3 requires a bit of extra memory
   * files ~25% smaller
   * faster loading inside paraview
   * `fluidLagrangianFormat` option in cfg files, ASCII/BINARY/BINARY_LOWMEM
* `exportParaviewParticles_binaryv3()`
   * Same implementation as v3 above
   * probably faster, files a bit smaller
   * `partExpFormat` option in cfg files, ASCII/BINARY
