### PR TITLE
Continuous Integration

### DIFF
--- a/.github/problem-matchers.json
+++ b/.github/problem-matchers.json
@@ -1,0 +1,43 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "gcc",
+            "pattern": [
+                {
+                    "regexp": "^(.*):(\\d+):(\\d+):\\s+(?:fatal\\s+)?(warning|error):\\s+(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
+                }
+            ]
+        },
+        {
+            "owner": "msbuild",
+            "pattern": [
+                {
+                    "regexp": "^(?:\\s+\\d+\\>)?([^\\s].*)\\((\\d+),?(\\d+)?(?:,\\d+,\\d+)?\\)\\s*:\\s+(error|warning|info)\\s+(\\w{1,2}\\d+)\\s*:\\s*(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "code": 5,
+                    "message": 6
+                }
+            ]
+        },
+        {
+            "owner": "nvcc",
+            "pattern": [
+                {
+                    "regexp": "^(?:\\s+\\d+\\>)?([^\\s].*)\\((\\d+)\\):\\s+(warning|error)\\s*:\\s+(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "severity": 3,
+                    "message": 4
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -1,0 +1,126 @@
+# Guidance: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions
+# Compile project on Ubuntu
+name: Ubuntu
+
+on:
+  # Branch pushes that do not only modify other workflow files
+  push:
+    branches:
+      - '**'
+    paths:
+      - "**"
+      - "!.github/**"
+      - "!matlab/**"
+      - ".github/workflows/Ubuntu.yml"
+  # Pull requests to main, that do not only modify other workflow files
+  pull_request:
+    branches:
+      - 'main'
+    paths:
+      - "**"
+      - "!.github/**"
+      - "!matlab/**"
+      - ".github/workflows/Windows.yml"
+  # Allow manual invocation.
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ${{ matrix.cxx.os }}
+    strategy:
+      fail-fast: false
+      # Multiplicative build matrix
+      # optional exclude: can be partial, include: must be specific
+      matrix:
+        cxx:
+          - compiler: gcc-12
+            os: ubuntu-22.04
+          - compiler: gcc-11
+            os: ubuntu-22.04
+          - compiler: gcc-8
+            os: ubuntu-20.04
+        config:
+          - name: "Release"
+            config: "Release"
+            OPENMP: "ON"
+          - name: "OpenMP-OFF"
+            config: "Release"
+            OPENMP: "OFF"
+          - name: "Debug"
+            config: "Debug"
+            OPENMP: "ON"
+        # exclude:
+        exclude:
+          # Exclude Debug and OpenMP Off for old GCC
+          - cxx:
+              compiler: gcc-11
+            config:
+              name: "Debug"
+          - cxx:
+              compiler: gcc-11
+            config:
+              name: "OpenMP-OFF"
+          - cxx:
+              compiler: gcc-8
+            config:
+              name: "Debug"
+          - cxx:
+              compiler: gcc-8
+            config:
+              name: "OpenMP-OFF"
+
+    # Name the job based on matrix/env options
+    name: "build (${{ matrix.cxx.compiler }}, ${{ matrix.config.name }}, ${{ matrix.cxx.os }})"
+
+    # Define job-wide env constants, and promote matrix elements to env constants for portable steps.
+    env:
+      # Workflow specific constants for building a specific example
+      # Compute the output name which should be unique within the matrix. This must be unique per build matrix/job combination
+      ARTIFACT_NAME: hybird-${{ matrix.cxx.os }}-${{ matrix.cxx.compiler }}-${{ matrix.config.name }}
+      # Define constants
+      BUILD_DIR: "build"
+      COMPILER: ${{ matrix.cxx.compiler }}
+      OS: ${{ matrix.cxx.os }}
+      CONFIG: ${{ matrix.config.config }}
+      OPENMP: ${{ matrix.config.OPENMP }}
+
+    # What the CI actually runs
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install/Select gcc and g++
+      if: ${{ startsWith(env.COMPILER, 'gcc-') }}
+      run: |
+        gcc_version=${COMPILER//gcc-/}
+        sudo apt-get install -y gcc-${gcc_version} g++-${gcc_version}
+        echo "CC=/usr/bin/gcc-${gcc_version}" >> $GITHUB_ENV
+        echo "CXX=/usr/bin/g++-${gcc_version}" >> $GITHUB_ENV
+
+    # Problem matchers allow compilation warnings/errors to be highlighted on GitHub
+    - name: Add custom problem matchers for annotations
+      run: echo "::add-matcher::.github/problem-matchers.json"
+
+    - name: Configure cmake
+      run: >
+        cmake . -B "${{ env.BUILD_DIR }}"
+        -DCMAKE_BUILD_TYPE="${{ env.CONFIG }}"
+        -DHYBIRD_ENABLE_OPENMP="${{ env.OPENMP }}"
+      # -Werror=dev
+
+    - name: Build hybird
+      working-directory: ${{ env.BUILD_DIR }}
+      run: cmake --build . --target hybird --verbose --parallel `nproc`
+
+    # Upload wheel artifacts to the job on GHA, with a short retention
+    # Use a unique name per job matrix run, to avoid a risk of corruption according to the docs (although it should work with unique filenames)
+    - name: Upload Wheel Artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.BUILD_DIR }}/bin/${{ env.CONFIG }}/hybird
+        if-no-files-found: error
+        retention-days: 5

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -1,0 +1,97 @@
+# Guidance: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions
+# Compile project on Windows
+name: Windows
+
+on:
+  # Branch pushes, that do not only modify other workflow files
+  push:
+    branches:
+      - '**'
+    paths:
+      - "**"
+      - "!.github/**"
+      - "!matlab/**"
+      - ".github/workflows/Windows.yml"
+  # Pull requests to main, that do not only modify other workflow files
+  pull_request:
+    branches:
+      - 'main'
+    paths:
+      - "**"
+      - "!.github/**"
+      - "!matlab/**"
+      - ".github/workflows/Windows.yml"
+  # Allow manual invocation.
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ${{ matrix.cxx.os }}
+    strategy:
+      fail-fast: false
+      # Multiplicative build matrix
+      # optional exclude: can be partial, include: must be specific
+      matrix:
+        cxx:
+          - compiler: "Visual Studio 17 2022"
+            os: windows-2022
+        config:
+          - name: "Release"
+            config: "Release"
+            OPENMP: "ON"
+          - name: "OpenMP-OFF"
+            config: "Release"
+            OPENMP: "OFF"
+          - name: "Debug"
+            config: "Debug"
+            OPENMP: "ON"
+        # exclude:
+
+    # Name the job based on matrix/env options
+    name: "build (${{ matrix.cxx.compiler }}, ${{ matrix.config.name }}, ${{ matrix.cxx.os }})"
+
+    # Define job-wide env constants, and promote matrix elements to env constants for portable steps.
+    env:
+      # Workflow specific constants for building a specific example
+      # Compute the output name which should be unique within the matrix. This must be unique per build matrix/job combination
+      ARTIFACT_NAME: hybird-${{ matrix.cxx.os }}-${{ matrix.config.name }}
+      # Define constants
+      BUILD_DIR: "build"
+      COMPILER: ${{ matrix.cxx.compiler }}
+      OS: ${{ matrix.cxx.os }}
+      CONFIG: ${{ matrix.config.config }}
+      OPENMP: ${{ matrix.config.OPENMP }}
+
+    # What the CI actually runs
+    steps:
+    - uses: actions/checkout@v4
+
+    # Problem matchers allow compilation warnings/errors to be highlighted on GitHub
+    - name: Add custom problem matchers for annotations
+      run: echo "::add-matcher::.github/problem-matchers.json"
+
+    # Must pass -G -A for windows, and -DPython3_ROOT_DIR/-DPYTHON3_EXECUTABLE as a github action workaround
+    - name: Configure cmake
+      run: >
+        cmake . -B "${{ env.BUILD_DIR }}" 
+        -G "${{ env.COMPILER }}" -A x64
+        -DHYBIRD_ENABLE_OPENMP="${{ env.OPENMP }}"
+      # -Werror=dev
+
+    - name: Build hybird
+      working-directory: ${{ env.BUILD_DIR }}
+      run: cmake --build . --config ${{ env.CONFIG }} --target hybird --verbose --parallel `nproc`
+
+    # Upload wheel artifacts to the job on GHA, with a short retention
+    # Use a unique name per job matrix run, to avoid a risk of corruption according to the docs (although it should work with unique filenames)
+    - name: Upload Wheel Artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.BUILD_DIR }}/bin/${{ env.CONFIG }}/hybird.exe
+        if-no-files-found: error
+        retention-days: 5

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ set(HYBIRD_INCLUDE
     ${PROJECT_SOURCE_DIR}/src/myvector.inl
     ${PROJECT_SOURCE_DIR}/src/node.h
     ${PROJECT_SOURCE_DIR}/src/utils.h
+    ${PROJECT_SOURCE_DIR}/src/Problem.h
     )
     
 # Define source files
@@ -32,10 +33,20 @@ set(HYBIRD_SRC
     ${PROJECT_SOURCE_DIR}/src/LB.cpp
     ${PROJECT_SOURCE_DIR}/src/node.cpp
     ${PROJECT_SOURCE_DIR}/src/utils.cpp
+    ${PROJECT_SOURCE_DIR}/src/Problem.cpp
     )
 
 # Define the target we wish to build
 add_executable(hybird ${HYBIRD_INCLUDE} ${HYBIRD_SRC})
+
+# Allow includes relative to src root
+target_include_directories(hybird PRIVATE "${PROJECT_SOURCE_DIR}/src")
+
+# Link with dependencies
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/dependencies/exprtk.cmake)
+target_link_libraries(hybird PRIVATE exprtk)
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/dependencies/yaml-cpp.cmake)
+target_link_libraries(hybird PRIVATE yaml-cpp)
 
 # Use C++17
 target_compile_features(hybird PUBLIC cxx_std_17)

--- a/cmake/dependencies/exprtk.cmake
+++ b/cmake/dependencies/exprtk.cmake
@@ -1,0 +1,32 @@
+############################################
+# Mathematical Expression Toolkit (exprtk) #
+############################################
+
+# Include FetchContent module
+include(FetchContent)
+
+# Declare ExprTk dependency
+FetchContent_Declare(
+    exprtk
+    GIT_REPOSITORY https://github.com/ArashPartow/exprtk.git
+    GIT_TAG 9910dc988d472d17ecf309c1c9c3e38430bd9c0f  # Specific commit for stability
+)
+
+# Make ExprTk available
+FetchContent_MakeAvailable(exprtk)
+
+# Create an interface library target for ExprTk
+add_library(exprtk INTERFACE)
+target_include_directories(exprtk INTERFACE ${exprtk_SOURCE_DIR})
+ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_compile_options(exprtk INTERFACE $<$<COMPILE_LANGUAGE:CXX>:/bigobj>)
+    #target_compile_options(exprtk INTERFACE $<$<COMPILE_LANGUAGE:CXX>:/W4>)
+    #target_compile_options(exprtk INTERFACE $<$<COMPILE_LANGUAGE:CXX>:/WX>)
+    target_compile_options(exprtk INTERFACE $<$<COMPILE_LANGUAGE:CXX>:/wd4334>)
+    target_compile_options(exprtk INTERFACE $<$<COMPILE_LANGUAGE:CXX>:/wd4702>)
+
+    target_compile_definitions(exprtk INTERFACE _SECURE_SCL=0            )
+    target_compile_definitions(exprtk INTERFACE _CRT_SECURE_NO_WARNINGS  )
+    target_compile_definitions(exprtk INTERFACE _SCL_SECURE_NO_WARNINGS  )
+    #target_compile_definitions(exprtk INTERFACE _HAS_ITERATOR_DEBUGGING=0)
+endif()

--- a/cmake/dependencies/yaml-cpp.cmake
+++ b/cmake/dependencies/yaml-cpp.cmake
@@ -1,0 +1,22 @@
+############
+# yaml-cpp #
+############
+
+# Include FetchContent module
+include(FetchContent)
+
+# Declare yaml-cpp dependency
+FetchContent_Declare(
+    yaml-cpp
+    GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
+    GIT_TAG 39f737443b05e4135e697cb91c2b7b18095acd53  # Specific commit for stability
+)
+
+# Configure yaml-cpp build options
+set(YAML_CPP_BUILD_TESTS OFF CACHE BOOL "disable yaml-cpp tests" FORCE)
+set(YAML_CPP_BUILD_TOOLS OFF CACHE BOOL "disable yaml-cpp tools" FORCE)
+set(YAML_CPP_BUILD_CONTRIB OFF CACHE BOOL "disable yaml-cpp contrib" FORCE)
+set(YAML_CPP_INSTALL OFF CACHE BOOL "disable yaml-cpp install targets" FORCE)
+
+# Make yaml-cpp available
+FetchContent_MakeAvailable(yaml-cpp)

--- a/problems/example.yml
+++ b/problems/example.yml
@@ -1,0 +1,51 @@
+# Name of the problem (0-1)
+name: example problem
+
+# If multiple fluid volumes are specified, they are all additive
+# Cuboid fluid volumes (0-many)
+fluids_basic:
+    - min: [-50, -50, -50]
+      max: [50, 50, 50]
+    - min: [10, 50, 10]
+      max: [10, 100.5, 10]
+# Mathematical expression fluid volumes (0-many)
+# Provide an expression that takes any/all (x/y/z)
+# Passed the coordinates of a node, it should return
+# >0 to denote that a node is fluid
+# <=0 to denote that a node is gas
+fluids_complex:
+    - (x + y)/z
+    
+    
+# Flat walls (0-many)
+walls:
+    - normal: [1,0,0]
+      point: [0,0,0]
+      # Remaining properties are optional, and will default to the below values if not specified
+      moving: false
+      rotational_center: [0,0,0]
+      rotational_speed: [0,0,0] # aka angular velocity?
+      translation_speed: [0,0,0] # aren't translation vector/speed the the same thing?
+      slipping: false
+      translating: false
+      translation_vector: [0,0,0]
+      limited: false
+      min: [-1.79769e+308, -1.79769e+308, -1.79769e+308] # aka -DBL_MAX
+      max: [1.79769e+308, 1.79769e+308, 1.79769e+308] # aka +DBL_MAX
+      
+      
+# Curved cylinders (0-many)
+cylinders:
+    - point1: [0,0,0]
+      point2: [1,0,0]
+      radius: 1
+      # Remaining properties are optional, and will default to the below values if not specified
+      moving: false
+      rotational_speed: [0,0,0]
+      slipping: false
+      empty: true # Define whether the cylinder is empty/inner or full/outer
+      translating: false
+      translation_vector: [0,0,0]
+      limited: false
+      min: [-1.79769e+308, -1.79769e+308, -1.79769e+308] # aka -DBL_MAX
+      max: [1.79769e+308, 1.79769e+308, 1.79769e+308] # aka +DBL_MAX

--- a/src/DEM.h
+++ b/src/DEM.h
@@ -22,6 +22,7 @@
 #include "utils.h"
 #include "LB.h"
 
+class Problem;
 using namespace std;
 extern ProblemName problemName;
 
@@ -182,7 +183,7 @@ public:
     }
     void discreteElementStep();
     void discreteElementGet(GetPot& config_file, GetPot& command_line);
-    void discreteElementInit(const typeList& externalBoundary, const doubleList& externalSize, const vecList& externalBoundaryLocation,
+    void discreteElementInit(const Problem& problem, const typeList& externalBoundary, const doubleList& externalSize, const vecList& externalBoundaryLocation,
             const tVect externalAccel, const tVect externalRotation, const tVect externalRotationCenter, const bool externalSolveCoriolis, const bool externalSolveCentrifugal, const double& externalTimeStep);
     void evolveBoundaries();
 //    void evolveObj();
@@ -192,8 +193,8 @@ public:
 private:
     // initialization functions
     void compositeProperties();
-    void initializeWalls(const typeList& boundary, const vecList& boundaryLocation);
-    void initializeCylinders();
+    void initializeWalls(const Problem& problem, const typeList& boundary, const vecList& boundaryLocation);
+    void initializeCylinders(const Problem& problem);
     void initializePbcs(const typeList& boundary, const vecList& boundaryLocation);
     // integration functions
     void predictor();

--- a/src/IO.h
+++ b/src/IO.h
@@ -63,7 +63,7 @@ public:
     // Formats for output
     enum ParaviewFormat {
         Binary, BinaryLowMem, Ascii
-    } fluidLagrangianFormat = Binary, partExpFormat = Binary;
+    } fluidFormat = Binary, fluidLagrangianFormat = Binary, partExpFormat = Binary;
     // recycle intervals
     double fluidRecycleExpTime, partRecycleExpTime, outputExpTime;
     // file for storing indices of single objects to export
@@ -142,6 +142,7 @@ private:
     unsigned int lastFluidLagrangianExp;
     string fluidLagrangianFileFormat;
     void exportLagrangianParaviewFluid(const LB& lb, const string& fluidFile);
+    void exportLagrangianParaviewFluid_binaryv3(const LB& lb, const string& fluidFile);
     
     // 2D files for GIS/////////////////////////////////////////////////////////////////////////////////////////
     

--- a/src/LB.cpp
+++ b/src/LB.cpp
@@ -1,10 +1,15 @@
  
 #include "LB.h"
 
+namespace {
+// extra mass due to bounce-back and moving walls
+// This is a reduction variable used by LB::streaming()
+// It is defined here so it can be shared by OpenMP threads nested inside a big OpenMP parallel block
+double extraMass = 0.0;
+}
 /*//////////////////////////////////////////////////////////////////////////////////////////////////////
  // PUBLIC FUNCTIONS
  //////////////////////////////////////////////////////////////////////////////////////////////////////*/
-
 void LB::LBShow() const {
     cout << "LATTICE CHARACTERISTICS (lattice units):" << endl;
     cout << "directions=" << lbmDirec << ";" << endl;
@@ -595,9 +600,7 @@ void LB::latticeBolzmannInit(cylinderList& cylinders, wallList& walls, particleL
     }
     cout << "Done with initialization" << endl;
 }
-
 void LB::latticeBolzmannStep(elmtList& elmts, particleList& particles, wallList& walls, objectList& objects) {
-
     // Lattice Boltzmann core steps
 
     // measure time for performance check (begin)
@@ -2334,7 +2337,7 @@ void LB::streaming(wallList& walls, objectList& objects) {
     #pragma omp single
     {
         // extra mass due to bounce-back and moving walls
-        this->extraMass = 0.0;
+        extraMass = 0.0;
         // initializing wall forces
         for (int iw = 0; iw < walls.size(); ++iw) {
             walls[iw].FHydro.reset();

--- a/src/LB.cpp
+++ b/src/LB.cpp
@@ -2162,7 +2162,7 @@ void LB::collision(node* nodeHere) {
         if (solveCentrifugal) {
             force+=nodeHere->centrifugalForce;
         }
-        if (solveCentrifugal) {
+        if (solveCoriolis) {
             force+=computeCoriolis(nodeHere->u,rotationSpeed);
         }
         // shift velocity field to F/2
@@ -2191,7 +2191,7 @@ void LB::collision(node* nodeHere) {
         if (solveCentrifugal) {
             force+=nodeHere->centrifugalForce;
         }
-        if (solveCentrifugal) {
+        if (solveCoriolis) {
             force+=computeCoriolis(nodeHere->u,rotationSpeed);
         }
         // shift velocity field to F/2

--- a/src/LB.cpp
+++ b/src/LB.cpp
@@ -2365,6 +2365,12 @@ void LB::streaming(wallList& walls, objectList& objects) {
     //        }
     //    }
 
+    //  Saving in support variables f->fs
+#pragma omp for
+    for (int it = 0; it < activeNodes.size(); ++it) {
+        activeNodes[it]->store();
+    }
+
     //  Streaming
 #pragma omp for ordered reduction(+:extraMass)
     // cycling through active nodes
@@ -2372,8 +2378,6 @@ void LB::streaming(wallList& walls, objectList& objects) {
 
         // pointer to active node
         node* nodeHere = activeNodes[in];
-        //  Saving in support variables f->fs
-        nodeHere->store();
         // cycling through neighbours
         for (int j = 1; j < lbmDirec; ++j) {
             // getting neighbour index

--- a/src/LB.cpp
+++ b/src/LB.cpp
@@ -3290,11 +3290,6 @@ void LB::computeSurfaceNormal() {
             }
         }
         surfaceNormalHere /= surfaceNormalHere.norm();
-        interfaceNodes[it]->surfaceNormal = surfaceNormalHere;
-    }
-#pragma omp parallel for
-    for (int it = 0; it < fluidNodes.size(); ++it) {
-        fluidNodes[it]->surfaceNormal = Zero;
     }
 
     // measure time for performance check (end)

--- a/src/LB.h
+++ b/src/LB.h
@@ -169,13 +169,9 @@ public:
     // age coefficients for new nodes
     const double maxAge=200.0;
     const double ageRatio=1.0/maxAge;
-    // extra mass due to bounce-back and moving walls
-    // This is a reduction variable used by LB::streaming()
-    // It is defined at a class level so it can be shared by OpenMP threads
-    double extraMass = 0.0;
-    // standard constructor
-public:
 
+ public:
+    // standard constructor
     LB() {
         boundary.resize(6);
         ne.resize(lbmDirec);

--- a/src/LB.h
+++ b/src/LB.h
@@ -28,6 +28,7 @@
 #include "elmt.h"
 #include "getpot.h"
 
+class Problem;
 using namespace std;
 extern ProblemName problemName;
 
@@ -181,7 +182,7 @@ public:
     void LBShow() const;
     void latticeDefinition();
     void latticeBoltzmannGet(GetPot& lbmCfgFile, GetPot& command_line);
-    void latticeBolzmannInit(cylinderList& cylinders, wallList& walls, particleList& particles, objectList& objects, const bool externalSolveCoriolis, const bool externalSolveCentrifugal);
+    void latticeBolzmannInit(Problem &problem, cylinderList& cylinders, wallList& walls, particleList& particles, objectList& objects, const bool externalSolveCoriolis, const bool externalSolveCentrifugal);
     void latticeBolzmannStep(elmtList& elmts, particleList& particles, wallList& walls, objectList& objects);
     void latticeBoltzmannCouplingStep(bool& newNeighborList, elmtList& eltms, particleList& particles);
     void latticeBoltzmannFreeSurfaceStep();
@@ -209,7 +210,7 @@ public:
     void initializeTopography();
     void initializeCurved(cylinderList& cylinders);
     void setTopographySurface();
-    void initializeInterface(double totParticles);
+    void initializeInterface(Problem& problem, double totParticles);
     void restartInterface(ifstream& fluidFileID, unsigned int& totNodes);
     void initializeLists();
     void resetLists();

--- a/src/Problem.cpp
+++ b/src/Problem.cpp
@@ -1,0 +1,237 @@
+#include "Problem.h"
+
+#include <yaml-cpp/yaml.h>
+#include <exprtk.hpp>
+
+Problem::Problem() {
+    symbol_table.add_variable("x", exprtk_pos.x);
+    symbol_table.add_variable("y", exprtk_pos.y);
+    symbol_table.add_variable("z", exprtk_pos.z);
+}
+
+inline bool parse_bool(const YAML::Node& node, const std::string &parent, const std::string &child) {
+    if (node[child].IsSequence()) {
+        std::stringstream err;
+        err << "'" << parent << "::" << child << "', if present, should be parseable as type boolean.";
+        std::cout << err.str();
+        throw std::exception(err.str().c_str());
+    }
+    return node[child].as<bool>();
+}
+inline tVect parse_tVect(const YAML::Node& node, const std::string& parent, const std::string& child) {
+    if (!node[child].IsSequence() || node[child].size() != 3) {
+        std::stringstream err;
+        err << "'" << parent << "::" << child << "', if present, should be parseable as type double[3].";
+        std::cout << err.str();
+        throw std::exception(err.str().c_str());
+    }
+    return { node[child][0].as<double>(), node[child][1].as<double>() , node[child][2].as<double>() };
+}
+inline exprtk::expression<double> parse_expression(exprtk::parser<double> &parser, exprtk::symbol_table<double> &symbol_table, const std::string &expression_string) {
+    exprtk::expression<double> expression;
+    expression.register_symbol_table(symbol_table);
+    if (!parser.compile(expression_string, expression)) {
+        std::stringstream err;
+        err << "Unable to parse expression '" << expression_string << "'.";
+        std::cout << err.str();
+        throw std::exception(err.str().c_str());
+    }
+    return expression;
+}
+Problem::MinMaxPair readBasicFluid(const YAML::Node &basic_fluid) {
+    // Validate it contains expected components
+    if (!basic_fluid["min"] || !basic_fluid["max"]
+        || !basic_fluid["min"].IsSequence() || !basic_fluid["max"].IsSequence()
+        || basic_fluid["min"].size() != 3 || basic_fluid["max"].size() != 3) {
+        const std::string err = "'fluids_basic' nodes should contain both a 'min' and 'max' type double[3].";
+        std::cout << err;
+        throw std::exception(err.c_str());
+    }
+    Problem::MinMaxPair rtn;
+    rtn.min.x = basic_fluid["min"][0].as<double>();
+    rtn.min.y = basic_fluid["min"][1].as<double>();
+    rtn.min.z = basic_fluid["min"][2].as<double>();
+    rtn.max.x = basic_fluid["max"][0].as<double>();
+    rtn.max.y = basic_fluid["max"][1].as<double>();
+    rtn.max.z = basic_fluid["max"][2].as<double>();
+    return rtn;
+}
+wall readWall(const YAML::Node& wall_node) {
+    // Validate it contains mandatory components
+    if (!wall_node["normal"] || !wall_node["point"]
+        || !wall_node["normal"].IsSequence() || !wall_node["point"].IsSequence()
+        || wall_node["normal"].size() != 3 || wall_node["point"].size() != 3) {
+        const std::string err = "'walls' nodes should contain both a 'normal' and 'point' as type double[3].";
+        std::cout << err;
+        throw std::exception(err.c_str());
+    }
+    wall rtn;
+    // Mandatory components
+    rtn.n.x = wall_node["normal"][0].as<double>();
+    rtn.n.y = wall_node["normal"][1].as<double>();
+    rtn.n.z = wall_node["normal"][2].as<double>();
+    rtn.p.x = wall_node["point"][0].as<double>();
+    rtn.p.y = wall_node["point"][1].as<double>();
+    rtn.p.z = wall_node["point"][2].as<double>();
+    // Optional components
+    if (wall_node["moving"]) {
+        rtn.moving = parse_bool(wall_node, "wall", "moving");
+    }
+    if (wall_node["rotational_center"]) {
+        rtn.rotCenter = parse_tVect(wall_node, "wall", "rotational_center");
+    }
+    if (wall_node["rotational_speed"]) {
+        rtn.omega = parse_tVect(wall_node, "wall", "rotational_speed");
+    }
+    if (wall_node["translation_speed"]) {
+        rtn.vel = parse_tVect(wall_node, "wall", "translation_speed");
+    }
+    if (wall_node["slipping"]) {
+        rtn.slip = parse_bool(wall_node, "wall", "slipping");
+    }
+    if (wall_node["translating"]) {
+        rtn.translating = parse_bool(wall_node, "wall", "translating");
+    }
+    if (wall_node["translation_vector"]) {
+        rtn.trans = parse_tVect(wall_node, "wall", "translation_vector");
+    }
+    if (wall_node["limited"]) {
+        rtn.limited = parse_bool(wall_node, "wall", "limited");
+    }
+    if (wall_node["min"]) {
+        const tVect t = parse_tVect(wall_node, "wall", "min");
+        rtn.xMin = t.x;
+        rtn.yMin = t.y;
+        rtn.zMin = t.z;
+    }
+    if (wall_node["max"]) {
+        const tVect t = parse_tVect(wall_node, "wall", "max");
+        rtn.xMax = t.x;
+        rtn.yMax = t.y;
+        rtn.zMax = t.z;
+    }
+    return rtn;
+}
+cylinder readCylinder(const YAML::Node& cylinder_node) {
+    // Validate it contains mandatory components
+    if (!cylinder_node["point1"] || !cylinder_node["point2"]
+        || !cylinder_node["point1"].IsSequence() || !cylinder_node["point2"].IsSequence()
+        || cylinder_node["point1"].size() != 3 || cylinder_node["point2"].size() != 3) {
+        const std::string err = "'cylinders' nodes should contain both a 'point1' and 'point2' as type double[3].";
+        std::cout << err;
+        throw std::exception(err.c_str());
+    }
+    if (!cylinder_node["radius"] || cylinder_node["radius"].IsSequence()) {
+        const std::string err = "'cylinders' nodes should contain a 'radius' as type double.";
+        std::cout << err;
+        throw std::exception(err.c_str());
+    }
+    cylinder rtn;
+    // Mandatory components
+    rtn.p1.x = cylinder_node["point1"][0].as<double>();
+    rtn.p1.y = cylinder_node["point1"][1].as<double>();
+    rtn.p1.z = cylinder_node["point1"][2].as<double>();
+    rtn.p2.x = cylinder_node["point2"][0].as<double>();
+    rtn.p2.y = cylinder_node["point2"][1].as<double>();
+    rtn.p2.z = cylinder_node["point2"][2].as<double>();
+    rtn.R = cylinder_node["radius"].as<double>();
+    // Optional components
+    if (cylinder_node["moving"]) {
+        rtn.moving = parse_bool(cylinder_node, "cylinder", "moving");
+    }
+    if (cylinder_node["rotational_speed"]) {
+        rtn.omega = parse_tVect(cylinder_node, "cylinder", "rotational_speed");
+    }
+    if (cylinder_node["slipping"]) {
+        rtn.slip = parse_bool(cylinder_node, "cylinder", "slipping");
+    }
+    if (cylinder_node["empty"]) {
+        rtn.type = parse_bool(cylinder_node, "cylinder", "empty") ? EMPTY : FULL;
+    }
+    if (cylinder_node["translating"]) {
+        rtn.translating = parse_bool(cylinder_node, "cylinder", "translating");
+    }
+    if (cylinder_node["translation_vector"]) {
+        rtn.trans = parse_tVect(cylinder_node, "cylinder", "translation_vector");
+    }
+    if (cylinder_node["limited"]) {
+        rtn.limited = parse_bool(cylinder_node, "cylinder", "limited");
+    }
+    if (cylinder_node["min"]) {
+        const tVect t = parse_tVect(cylinder_node, "cylinder", "min");
+        rtn.xMin = t.x;
+        rtn.yMin = t.y;
+        rtn.zMin = t.z;
+    }
+    if (cylinder_node["max"]) {
+        const tVect t = parse_tVect(cylinder_node, "cylinder", "max");
+        rtn.xMax = t.x;
+        rtn.yMax = t.y;
+        rtn.zMax = t.z;
+    }
+    return rtn;
+}
+
+
+Problem Problem::loadFile(const std::string& filePath) {
+    YAML::Node problem;
+    try {
+        problem = YAML::LoadFile(filePath);
+    } catch (YAML::BadFile&) {
+        std::stringstream err;
+        err << "Unable to open file '" << filePath << "' for reading, does it exist?";
+        std::cout << err.str();
+        throw std::exception(err.str().c_str());
+    }
+    Problem p;
+    // Name
+    if (problem["name"]) {
+        p.name = problem["name"].as<std::string>();
+    }
+    // Cuboid fluid volumes
+    if (problem["fluids_basic"]) {
+        if (problem["fluids_basic"].IsSequence()) {
+            for (const auto &fluid : problem["fluids_basic"]) {
+                p.fluids_basic.push_back(readBasicFluid(fluid));
+            }
+        } else {
+            // They didn't provide it as a list, parse anyway
+            readBasicFluid(problem["fluids_basic"]);
+        }
+    }
+    // Mathematical expression fluid volumes
+    if (problem["fluids_complex"]) {
+        exprtk::parser<double> parser;
+        if (problem["fluids_complex"].IsSequence()) {
+            for (const auto &fluid : problem["fluids_complex"]) {
+                p.fluids_complex.push_back(parse_expression(parser, p.symbol_table, fluid.as<std::string>()));
+            }
+        } else {
+            // They didn't provide it as a list, parse anyway
+            p.fluids_complex.push_back(parse_expression(parser, p.symbol_table, problem["fluids_complex"].as<std::string>()));
+        }        
+    }
+    // Walls
+    if (problem["walls"]) {
+        if (problem["walls"].IsSequence()) {
+            for (const auto &wall : problem["walls"]) {
+                p.walls.push_back(readWall(wall));
+            }
+        } else {
+            // They didn't provide it as a list, parse anyway
+            p.walls.push_back(readWall(problem["walls"]));
+        }        
+    }
+    // Cylinders
+    if (problem["cylinders"]) {
+        if (problem["cylinders"].IsSequence()) {
+            for (const auto& cylinder : problem["cylinders"]) {
+                p.cylinders.push_back(readCylinder(cylinder));
+            }
+        } else {
+            // They didn't provide it as a list, parse anyway
+            p.cylinders.push_back(readCylinder(problem["cylinders"]));
+        }
+    }
+    return p;
+}

--- a/src/Problem.cpp
+++ b/src/Problem.cpp
@@ -184,6 +184,7 @@ Problem Problem::loadFile(const std::string& filePath) {
         throw std::exception(err.str().c_str());
     }
     Problem p;
+    p.file = filePath;
     // Name
     if (problem["name"]) {
         p.name = problem["name"].as<std::string>();
@@ -204,11 +205,15 @@ Problem Problem::loadFile(const std::string& filePath) {
         exprtk::parser<double> parser;
         if (problem["fluids_complex"].IsSequence()) {
             for (const auto &fluid : problem["fluids_complex"]) {
-                p.fluids_complex.push_back(parse_expression(parser, p.symbol_table, fluid.as<std::string>()));
+                const std::string t = fluid.as<std::string>();
+                p.fluids_complex_str.push_back(t);
+                p.fluids_complex.push_back(parse_expression(parser, p.symbol_table, t));
             }
         } else {
             // They didn't provide it as a list, parse anyway
-            p.fluids_complex.push_back(parse_expression(parser, p.symbol_table, problem["fluids_complex"].as<std::string>()));
+            const std::string t = problem["fluids_complex"].as<std::string>();
+            p.fluids_complex_str.push_back(t);
+            p.fluids_complex.push_back(parse_expression(parser, p.symbol_table, t));
         }        
     }
     // Walls

--- a/src/Problem.cpp
+++ b/src/Problem.cpp
@@ -14,7 +14,7 @@ inline bool parse_bool(const YAML::Node& node, const std::string &parent, const 
         std::stringstream err;
         err << "'" << parent << "::" << child << "', if present, should be parseable as type boolean.";
         std::cout << err.str();
-        throw std::exception(err.str().c_str());
+        throw std::runtime_error(err.str().c_str());
     }
     return node[child].as<bool>();
 }
@@ -23,7 +23,7 @@ inline tVect parse_tVect(const YAML::Node& node, const std::string& parent, cons
         std::stringstream err;
         err << "'" << parent << "::" << child << "', if present, should be parseable as type double[3].";
         std::cout << err.str();
-        throw std::exception(err.str().c_str());
+        throw std::runtime_error(err.str().c_str());
     }
     return { node[child][0].as<double>(), node[child][1].as<double>() , node[child][2].as<double>() };
 }
@@ -34,7 +34,7 @@ inline exprtk::expression<double> parse_expression(exprtk::parser<double> &parse
         std::stringstream err;
         err << "Unable to parse expression '" << expression_string << "'.";
         std::cout << err.str();
-        throw std::exception(err.str().c_str());
+        throw std::runtime_error(err.str().c_str());
     }
     return expression;
 }
@@ -45,7 +45,7 @@ Problem::MinMaxPair readBasicFluid(const YAML::Node &basic_fluid) {
         || basic_fluid["min"].size() != 3 || basic_fluid["max"].size() != 3) {
         const std::string err = "'fluids_basic' nodes should contain both a 'min' and 'max' type double[3].";
         std::cout << err;
-        throw std::exception(err.c_str());
+        throw std::runtime_error(err.c_str());
     }
     Problem::MinMaxPair rtn;
     rtn.min.x = basic_fluid["min"][0].as<double>();
@@ -63,7 +63,7 @@ wall readWall(const YAML::Node& wall_node) {
         || wall_node["normal"].size() != 3 || wall_node["point"].size() != 3) {
         const std::string err = "'walls' nodes should contain both a 'normal' and 'point' as type double[3].";
         std::cout << err;
-        throw std::exception(err.c_str());
+        throw std::runtime_error(err.c_str());
     }
     wall rtn;
     // Mandatory components
@@ -119,12 +119,12 @@ cylinder readCylinder(const YAML::Node& cylinder_node) {
         || cylinder_node["point1"].size() != 3 || cylinder_node["point2"].size() != 3) {
         const std::string err = "'cylinders' nodes should contain both a 'point1' and 'point2' as type double[3].";
         std::cout << err;
-        throw std::exception(err.c_str());
+        throw std::runtime_error(err.c_str());
     }
     if (!cylinder_node["radius"] || cylinder_node["radius"].IsSequence()) {
         const std::string err = "'cylinders' nodes should contain a 'radius' as type double.";
         std::cout << err;
-        throw std::exception(err.c_str());
+        throw std::runtime_error(err.c_str());
     }
     cylinder rtn;
     // Mandatory components
@@ -181,7 +181,7 @@ Problem Problem::loadFile(const std::string& filePath) {
         std::stringstream err;
         err << "Unable to open file '" << filePath << "' for reading, does it exist?";
         std::cout << err.str();
-        throw std::exception(err.str().c_str());
+        throw std::runtime_error(err.str().c_str());
     }
     Problem p;
     p.file = filePath;

--- a/src/Problem.h
+++ b/src/Problem.h
@@ -16,9 +16,12 @@ class Problem {
     struct MinMaxPair {
         tVect min, max;
     };
+    std::string file;
     std::string name;
     std::vector<MinMaxPair> fluids_basic;
     std::vector<exprtk::expression<double>> fluids_complex;
+    // String representation of loaded expressions
+    std::vector<std::string> fluids_complex_str;
     std::vector<wall> walls;
     std::vector<cylinder> cylinders;
     /**
@@ -37,7 +40,7 @@ class Problem {
      * @return True if the node is fluid
      * @note Defined here so that it is inlined as this may be called millions of times during init
      */
-    bool isFluid(const tVect& pos) {
+    bool isFluid(const tVect& pos) const {
         // Check basic fluid volumes
         if (std::any_of(fluids_basic.cbegin(), fluids_basic.cend(),
             // Lambda function
@@ -55,7 +58,7 @@ class Problem {
             [](const exprtk::expression<double>& expr) { return expr.value() > 0; });
     }
 private:
-    tVect exprtk_pos;
+    mutable tVect exprtk_pos;
     exprtk::symbol_table<double> symbol_table;
 };
 

--- a/src/Problem.h
+++ b/src/Problem.h
@@ -1,0 +1,62 @@
+#ifndef PROBLEM_H
+#define PROBLEM_H
+#include <string>
+#include <vector>
+
+#include <exprtk.hpp>
+
+#include "utils.h"
+
+/**
+ * Represents a problem input file, and supports loading them from .yml format
+ * Problems contain fluid volumes, walls and cylinders
+ */
+class Problem {
+ public:
+    struct MinMaxPair {
+        tVect min, max;
+    };
+    std::string name;
+    std::vector<MinMaxPair> fluids_basic;
+    std::vector<exprtk::expression<double>> fluids_complex;
+    std::vector<wall> walls;
+    std::vector<cylinder> cylinders;
+    /**
+     * Init exprtk components
+     */
+    Problem();
+    /**
+     * Attempt to load the specified .yml problem file and return it as a Problem object
+     * @param filePath Path to .yml containing problem
+     * @note Static "factory" because constructors are not supposed to throw exceptions (e.g. if file not exist)
+     */
+    static Problem loadFile(const std::string &filePath);
+
+    /**
+     * @param pos Coordinate to test
+     * @return True if the node is fluid
+     * @note Defined here so that it is inlined as this may be called millions of times during init
+     */
+    bool isFluid(const tVect& pos) {
+        // Check basic fluid volumes
+        if (std::any_of(fluids_basic.cbegin(), fluids_basic.cend(),
+            // Lambda function
+            [&pos](const MinMaxPair& minmax) {
+                return (pos.x >= minmax.min.x && pos.x <= minmax.max.x
+                     && pos.y >= minmax.min.y && pos.y <= minmax.max.y
+                     && pos.z >= minmax.min.z && pos.z <= minmax.max.z);
+            })) {
+                return true;
+        }
+        // Check complex fluid volumes
+        exprtk_pos = pos;
+        return std::any_of(fluids_complex.cbegin(), fluids_complex.cend(),
+            // Lambda function
+            [](const exprtk::expression<double>& expr) { return expr.value() > 0; });
+    }
+private:
+    tVect exprtk_pos;
+    exprtk::symbol_table<double> symbol_table;
+};
+
+#endif // PROBLEM_H

--- a/src/getpot.h
+++ b/src/getpot.h
@@ -29,6 +29,9 @@
 #define __GETPOT_H__
 
 #if defined(WIN32) || defined(SOLARIS_RAW) || (__GNUC__ == 2) || defined(__HP_aCC)
+#ifndef _CRT_SECURE_NO_WARNINGS
+#define _CRT_SECURE_NO_WARNINGS
+#endif
 #define strtok_r(a, b, c) strtok(a, b)
 #endif // WINDOWS or SOLARIS or gcc 2.* or HP aCC
 

--- a/src/getpot.h
+++ b/src/getpot.h
@@ -843,7 +843,7 @@ GetPot::_parse_argument_vector(const STRING_VECTOR& ARGV)
 inline STRING_VECTOR
 GetPot::_read_in_file(const std::string& FileName)
 {
-    std::ifstream  i(FileName.c_str());
+    std::ifstream  i(FileName.c_str(), std::ios::binary);
     if( ! i ) return STRING_VECTOR();
     // argv[0] == the filename of the file that was read in
     return _read_in_stream(i);
@@ -923,7 +923,6 @@ GetPot::_skip_whitespace(std::istream& istr)
 	    tmp = istr.get();
 	    if( ! istr ) return;
 	}
-
 	// -- look if characters match the comment starter string
 	const std::istream::pos_type  Pos = istr.tellg();
 	unsigned    i=0;
@@ -931,7 +930,7 @@ GetPot::_skip_whitespace(std::istream& istr)
 	    if( tmp != _comment_start[i] ) {
 		istr.seekg(Pos);
 		// -- one step more backwards, since 'tmp' already at non-whitespace
-		istr.unget();
+		istr.unget(); // MSVC bugfix!
 		return;
 	    }
 

--- a/src/hybird.cpp
+++ b/src/hybird.cpp
@@ -513,11 +513,11 @@ int main(int argc, char** argv) {
     const tVect externalRotation = lb.rotationSpeed * lb.unit.AngVel;
     const tVect externalRotationCenter = lb.rotationCenter * lb.unit.Length;
 
-    dem.discreteElementInit(lb.boundary, lb.lbPhysicalSize, lb.lbBoundaryLocation, externalForce,
+    dem.discreteElementInit(problem, lb.boundary, lb.lbPhysicalSize, lb.lbBoundaryLocation, externalForce,
             externalRotation, externalRotationCenter, io.coriolisSolver, io.centrifugalSolver, lb.unit.Time);
 
     if (io.lbmSolver) {
-        lb.latticeBolzmannInit(dem.cylinders, dem.walls, dem.particles, dem.objects, io.coriolisSolver, io.centrifugalSolver);
+        lb.latticeBolzmannInit(problem, dem.cylinders, dem.walls, dem.particles, dem.objects, io.coriolisSolver, io.centrifugalSolver);
     }
 
     // setting time

--- a/src/hybird.cpp
+++ b/src/hybird.cpp
@@ -222,6 +222,18 @@ void parseConfigFile(IO& io, DEM& dem, LB& lb, Problem& problem, GetPot& configF
     ASSERT(io.screenExpTime >= 0);
     PARSE_CLASS_MEMBER(configFile, io.fluidExpTime, "fluidExpTime", 0.0);
     ASSERT(io.fluidExpTime >= 0);
+    if (io.fluidLagrangianExpTime > 0.0) {
+        string fluidFormatString;
+        PARSE_CLASS_MEMBER(configFile, fluidFormatString, "fluidFormat", "BINARY");
+        std::transform(fluidFormatString.begin(), fluidFormatString.end(), fluidFormatString.begin(), ::tolower);
+        if (fluidFormatString == "ascii"
+            || fluidFormatString == "text"
+            || fluidFormatString == "txt") {
+            io.fluidFormat = IO::ParaviewFormat::Ascii;
+        } else { // "binary"
+            io.fluidFormat = IO::ParaviewFormat::Binary;
+        }
+    }
     PARSE_CLASS_MEMBER(configFile, io.fluidLagrangianExpTime, "fluidLagrangianExpTime", 0.0);
     ASSERT(io.fluidLagrangianExpTime >= 0);
     if (io.fluidLagrangianExpTime > 0.0) {
@@ -232,14 +244,14 @@ void parseConfigFile(IO& io, DEM& dem, LB& lb, Problem& problem, GetPot& configF
          || fluidLagrangianFormatString == "text"
          || fluidLagrangianFormatString == "txt") {
             io.fluidLagrangianFormat = IO::ParaviewFormat::Ascii;
-         } else if (fluidLagrangianFormatString == "binary_low_memory"
-                 || fluidLagrangianFormatString == "binary_lowmem"
-                 || fluidLagrangianFormatString == "low_memory"
-                 || fluidLagrangianFormatString == "lowmem") {
-             io.fluidLagrangianFormat = IO::ParaviewFormat::BinaryLowMem;
-         } else { // "binary"
-                     io.fluidLagrangianFormat = IO::ParaviewFormat::Binary;
-         }
+        } else if (fluidLagrangianFormatString == "binary_low_memory"
+                || fluidLagrangianFormatString == "binary_lowmem"
+                || fluidLagrangianFormatString == "low_memory"
+                || fluidLagrangianFormatString == "lowmem") {
+            io.fluidLagrangianFormat = IO::ParaviewFormat::BinaryLowMem;
+        } else { // "binary"
+            io.fluidLagrangianFormat = IO::ParaviewFormat::Binary;
+        }
     }
     PARSE_CLASS_MEMBER(configFile, io.fluid2DExpTime, "fluid2DExpTime", 0.0);
     ASSERT(io.fluid2DExpTime >= 0);

--- a/src/hybird.cpp
+++ b/src/hybird.cpp
@@ -14,6 +14,7 @@
 #include "IO.h"
 #include "DEM.h"
 #include "LB.h"
+#include "Problem.h"
 
 /*
  *      HYBIRD
@@ -25,7 +26,7 @@
 
 
 enum ExitCode {
-    UNFINISHED = -1, SUCCESS = 0, TIME_LIMIT_REACHED, SIGNAL_CAUGHT, ERROR
+    UNFINISHED = -1, SUCCESS = 0, TIME_LIMIT_REACHED, SIGNAL_CAUGHT, ERR
 };
 
 
@@ -147,13 +148,12 @@ void parseCommandLine(IO& io, GetPot& commandLine) {
     std::ifstream configFile(io.configFileName.c_str());
     if (!configFile) {
         cout << "ERROR: Can't open config file \"" << io.configFileName << "\" for reading!\n";
-        //        return ERROR;
+        //        return ERR;
     }
     configFile.close();
 }
 
-void parseConfigFile(IO& io, DEM& dem, LB& lb, GetPot& configFile, GetPot& commandLine) {
-
+void parseConfigFile(IO& io, DEM& dem, LB& lb, Problem& problem, GetPot& configFile, GetPot& commandLine) {
     cout << "Parsing input file" << endl;
     // PROBLEM NAME //////////////
     // necessary for hard coded sections of the code
@@ -195,8 +195,11 @@ void parseConfigFile(IO& io, DEM& dem, LB& lb, GetPot& configFile, GetPot& comma
     else if (problemNameString == "SHEARCELL2022") problemName = SHEARCELL2023;
     else if (problemNameString == "INTRUDER") problemName = INTRUDER;
     else if (problemNameString == "OBJMOVING") problemName = OBJMOVING;
-
-
+    string problemFileString;
+    PARSE_CLASS_MEMBER(configFile, problemFileString, "problemFile", "");
+    if (!problemFileString.empty()) {
+        problem = Problem::loadFile(problemFileString);
+    }
 
     // GETTING SIMULATION PARAMETERS  /////////
     // DEM initial iterations
@@ -480,7 +483,8 @@ int main(int argc, char** argv) {
 
     // parsing LBM input file
     GetPot configFile(io.configFileName);
-    parseConfigFile(io, dem, lb, configFile, commandLine);
+    Problem problem;
+    parseConfigFile(io, dem, lb, problem, configFile, commandLine);
 
     printUfo(commandLine, configFile);
 
@@ -541,7 +545,7 @@ int main(int argc, char** argv) {
 
             //            // exit abnormally if a serious problem has occurred
             //            if (io.problem) {
-            //                exit_code = ERROR;
+            //                exit_code = ERR;
             //            }
         }
 

--- a/src/node.h
+++ b/src/node.h
@@ -77,14 +77,10 @@ public:
     double fs[lbmDirec];
     // density in the node
     double n;
-    // smoothed pressure in the node
-    double smoothedPressure;
     // velocity of fluid in node
     tVect u;
     // DEM-coupling forces on the node
     tVect hydroForce;
-    // surface normal
-    tVect surfaceNormal;
     // centrifugal force on the node
     tVect centrifugalForce;
     // mass functions
@@ -119,7 +115,6 @@ public:
     // default constructor
     node(){
         n=0.0;
-        smoothedPressure=0.0;
         u.reset();
         hydroForce.reset();
         centrifugalForce.reset();

--- a/tutorials/bingham_flow/bingham_flow.cfg
+++ b/tutorials/bingham_flow/bingham_flow.cfg
@@ -13,9 +13,11 @@ problemName             = NULL	    #
 # OUTPUT
 screenExpTime           = 0.1		    # print data on screen every x time (0 for deactivated)
 fluidExpTime            = 0		    # write vtk file every x time (0 for deactivated)
+fluidFormat             = ASCII     # ASCII/BINARY/BINARY_LOWMEM (defaults BINARY, fastest/smallest, requires extra RAM)
 fluidLagrangianExpTime  = 1.0		    # write Lagrangian vtk file every x time (0 for deactivated)
-fluidLagrangianFormat   = ASCII     # ASCII/BINARY/BINARY_LOWMEM (defaults BINARY, fastest/smallest, requires extra RAM)
+fluidLagrangianFormat   = ASCII     # ASCII/BINARY (defaults BINARY, fastest/smallest)
 partExpTime             = 0			    # write vtk file every x time (0 for deactivated)
+partExpFormat           = ASCII		# ASCII/BINARY (defaults BINARY, fastest/smallest)
 partRecycleExpTime      = 0		    # write particle recycle file every x time (0 for deactivated)
 fluidRecycleExpTime     = 0		    # write particle recycle file every x simulation time units (0 for deactivated)
 fluid2DExpTime          = 0         # write a 2D topographycal file every x time. Maximum values are updated every screenExpTime

--- a/tutorials/granular_column/granular_colum.cfg
+++ b/tutorials/granular_column/granular_colum.cfg
@@ -13,7 +13,9 @@ problemName             = NULL	    #
 # OUTPUT
 screenExpTime           = 1.0e-2		    # print data on screen every x time (0 for deactivated)
 fluidExpTime            = 0		    # write vtk file every x time (0 for deactivated)
+fluidFormat             = ASCII  # ASCII/BINARY/BINARY_LOWMEM (defaults BINARY, fastest/smallest, requires extra RAM)
 fluidLagrangianExpTime  = 0		    # write Lagrangian vtk file every x time (0 for deactivated)
+fluidLagrangianFormat   = ASCII   # ASCII/BINARY (defaults BINARY, fastest/smallest)
 partExpTime             = 1.0e-2			    # write vtk file every x time (0 for deactivated)
 partExpFormat           = ASCII		# ASCII/BINARY (defaults BINARY, fastest/smallest)
 partRecycleExpTime      = 1.0e-1		    # write particle recycle file every x time (0 for deactivated)

--- a/tutorials/granular_flow/granular_flow.cfg
+++ b/tutorials/granular_flow/granular_flow.cfg
@@ -13,9 +13,11 @@ problemName             = NULL	    #
 # OUTPUT
 screenExpTime           = 0.1		    # print data on screen every x time (0 for deactivated)
 fluidExpTime            = 0		    # write vtk file every x time (0 for deactivated)
+fluidFormat             = ASCII     # ASCII/BINARY/BINARY_LOWMEM (defaults BINARY, fastest/smallest, requires extra RAM)
 fluidLagrangianExpTime  = 1.0		    # write Lagrangian vtk file every x time (0 for deactivated)
-fluidLagrangianFormat   = ASCII     # ASCII/BINARY/BINARY_LOWMEM (defaults BINARY, fastest/smallest, requires extra RAM)
+fluidLagrangianFormat   = ASCII     # ASCII/BINARY (defaults BINARY, fastest/smallest)
 partExpTime             = 0			    # write vtk file every x time (0 for deactivated)
+partExpFormat           = ASCII		# ASCII/BINARY (defaults BINARY, fastest/smallest)
 partRecycleExpTime      = 0		    # write particle recycle file every x time (0 for deactivated)
 fluidRecycleExpTime     = 0		    # write particle recycle file every x simulation time units (0 for deactivated)
 fluid2DExpTime          = 0         # write a 2D topographycal file every x time. Maximum values are updated every screenExpTime

--- a/tutorials/laminar_flow/laminar_flow.cfg
+++ b/tutorials/laminar_flow/laminar_flow.cfg
@@ -13,8 +13,11 @@ problemName             = NULL	    #
 # OUTPUT
 screenExpTime           = 0.1		    # print data on screen every x time (0 for deactivated)
 fluidExpTime            = 1.0		    # write vtk file every x time (0 for deactivated)
+fluidFormat             = ASCII     # ASCII/BINARY/BINARY_LOWMEM (defaults BINARY, fastest/smallest, requires extra RAM)
 fluidLagrangianExpTime  = 0		    # write Lagrangian vtk file every x time (0 for deactivated)
+fluidLagrangianFormat   = ASCII     # ASCII/BINARY (defaults BINARY, fastest/smallest)
 partExpTime             = 0			    # write vtk file every x time (0 for deactivated)
+partExpFormat           = ASCII		# ASCII/BINARY (defaults BINARY, fastest/smallest)
 partRecycleExpTime      = 0		    # write particle recycle file every x time (0 for deactivated)
 fluidRecycleExpTime     = 0		    # write particle recycle file every x simulation time units (0 for deactivated)
 fluid2DExpTime          = 0         # write a 2D topographycal file every x time. Maximum values are updated every screenExpTime

--- a/tutorials/laminar_flow/laminar_flow.cfg.bak
+++ b/tutorials/laminar_flow/laminar_flow.cfg.bak
@@ -13,8 +13,11 @@ problemName             = NULL	    #
 # OUTPUT
 screenExpTime           = 0.2		    # print data on screen every x time (0 for deactivated)
 fluidExpTime            = 0.2		    # write vtk file every x time (0 for deactivated)
+fluidFormat             = ASCII     # ASCII/BINARY/BINARY_LOWMEM (defaults BINARY, fastest/smallest, requires extra RAM)
 fluidLagrangianExpTime  = 0		    # write Lagrangian vtk file every x time (0 for deactivated)
+fluidLagrangianFormat   = ASCII     # ASCII/BINARY (defaults BINARY, fastest/smallest)
 partExpTime             = 0			    # write vtk file every x time (0 for deactivated)
+partExpFormat           = ASCII		# ASCII/BINARY (defaults BINARY, fastest/smallest)
 partRecycleExpTime      = 0		    # write particle recycle file every x time (0 for deactivated)
 fluidRecycleExpTime     = 0		    # write particle recycle file every x simulation time units (0 for deactivated)
 fluid2DExpTime          = 0         # write a 2D topographycal file every x time. Maximum values are updated every screenExpTime

--- a/tutorials/tsunami_wave/tsunami_wave.cfg
+++ b/tutorials/tsunami_wave/tsunami_wave.cfg
@@ -13,7 +13,9 @@ problemName             = NULL	    #
 # OUTPUT
 screenExpTime           = 1.0e-2		    # print data on screen every x time (0 for deactivated)
 fluidExpTime            = 1.0e-2		    # write vtk file every x time (0 for deactivated)
+fluidFormat             = BINARY  # ASCII/BINARY/BINARY_LOWMEM (defaults BINARY, fastest/smallest, requires extra RAM)
 fluidLagrangianExpTime  = 0		    # write Lagrangian vtk file every x time (0 for deactivated)
+fluidLagrangianFormat   = BINARY  # ASCII/BINARY (defaults BINARY, fastest/smallest)
 partExpTime             = 1.0e-2			    # write vtk file every x time (0 for deactivated)
 partExpFormat           = ASCII		# ASCII/BINARY (defaults BINARY, fastest/smallest)
 partRecycleExpTime      = 1.0e-1		    # write particle recycle file every x time (0 for deactivated)


### PR DESCRIPTION
Builds are automatically tested with Visual Studio 2022, and the latest 3 major versions of GCC.
Build configs include Debug/Release/Release+OpenMP=OFF

No current tests for linting, or compilation warnings.

![image](https://github.com/user-attachments/assets/33e9677f-142f-446a-88c8-6fe38ab2f50c)

## Additional changes
* Fixed `getpot.h` so it can parse files when compiled with Visual Studio
* Fixed OpenMP reduction to compile under Visual Studio (since I merged all the loops into a large OpenMP parallel section, scoping the reduction variable got a bit awkward).
* Fixed bug #13, where `solveCentrifugal` was being used in-place of `solveCoriolis`
* Fixed bug introduced in #11, where `linkNode->fs` could be read before update during `LB::streaming()`
