### PR TITLE
Update exprtk.cmake version

### DIFF
--- a/cmake/dependencies/exprtk.cmake
+++ b/cmake/dependencies/exprtk.cmake
@@ -9,7 +9,7 @@ include(FetchContent)
 FetchContent_Declare(
     exprtk
     GIT_REPOSITORY https://github.com/ArashPartow/exprtk.git
-    GIT_TAG 9910dc988d472d17ecf309c1c9c3e38430bd9c0f  # Specific commit for stability
+    GIT_TAG a4b17d543f072d2e3ba564e4bc5c3a0d2b05c338  # Specific commit from release branch for stability
 )
 
 # Make ExprTk available


### PR DESCRIPTION
It appears the developer behind exprtk has rebased, updated commit hashes. CMake was failing to configure on the previous orphaned commit.